### PR TITLE
Update AltStore version to prevent "no provisioning profile [...]" error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,8 +18,8 @@ echo "Checking source"
 if [[ ! -e "AltServer" ]]; then
     curl -L https://github.com/NyaMisty/AltServer-Linux/releases/download/v0.0.5/AltServer-"$ARCH" > AltServer
 fi
-if [[ ! -e "AltStore.ipa" ]]; then
-    curl -L https://cdn.altstore.io/file/altstore/apps/altstore/1_5_1.ipa > AltStore.ipa
+if [[ ! -e "AltStore.ipa" ]] || !( md5sum AltStore.ipa | cut -f 1 -d " " | grep -q "e3ac2bd77cedf0fa80531023d402ba83" ); then
+    curl -L https://cdn.altstore.io/file/altstore/apps/altstore/1_6_2.ipa > AltStore.ipa
 fi
 if [[ ! -e "main" ]]; then
     wget https://github.com/powenn/AltServer-Linux-ShellScript/raw/main/main

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ echo "Checking source"
 if [[ ! -e "AltServer" ]]; then
     curl -L https://github.com/NyaMisty/AltServer-Linux/releases/download/v0.0.5/AltServer-"$ARCH" > AltServer
 fi
-if [[ ! -e "AltStore.ipa" ]] || !( md5sum AltStore.ipa | cut -f 1 -d " " | grep -q "e3ac2bd77cedf0fa80531023d402ba83" ); then
+if [[ ! -e "AltStore.ipa" ]] || !( md5sum AltStore.ipa | cut -d " " -f 1 | grep -q "e3ac2bd77cedf0fa80531023d402ba83" ); then
     curl -L https://cdn.altstore.io/file/altstore/apps/altstore/1_6_2.ipa > AltStore.ipa
 fi
 if [[ ! -e "main" ]]; then


### PR DESCRIPTION
I was wondering why `AltStore` stopped working on my iPhone a few days ago. Then I quickly found out via a error message, that the latest `version 1.6.2` must be installed manually, otherwise the current installation is broken. 

> Fixed “no provisioning profile with the requested identifier…” error when sideloading and refreshing apps

[Source](https://faq.altstore.io/release-notes/altstore#altstore-1.6.2)

This is currently not possible with this script, because `version 1.5.1` was hard-coded. This update now checks if the `AltStore.ipa` file is available and if the md5 hash is the one of `version 1.6.2` and downloads it if necessary.

`AltStore 1.6.2` was tested with `iOS 16.3.1` and now everything works again.